### PR TITLE
Add Voting to Posts

### DIFF
--- a/src/components/Feed/Comments/CreateComment.tsx
+++ b/src/components/Feed/Comments/CreateComment.tsx
@@ -51,7 +51,8 @@ export default function CreateComment({
                   if (post.id === postId) {
                     return {
                       ...post,
-                      numComments: (post.numComments + 1) as number,
+                      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                      numComments: (post.numComments + 1),
                     };
                   }
                   return post;

--- a/src/components/Feed/Comments/CreateComment.tsx
+++ b/src/components/Feed/Comments/CreateComment.tsx
@@ -1,9 +1,11 @@
 import { useGlobalContext } from "@/providers/GlobalContext";
-import { api } from "@/utils/api";
+import { type RouterOutputs, api } from "@/utils/api";
 import { useSession } from "next-auth/react";
 import { useState } from "react";
 import Avatar from "../Avatar";
 import { cn } from "@/utils/cn";
+import { getQueryKey } from "@trpc/react-query";
+import { type InfiniteData, useQueryClient } from "@tanstack/react-query";
 
 export default function CreateComment({
   postId,
@@ -20,6 +22,9 @@ export default function CreateComment({
   );
   const mutate = api.comments.create.useMutation();
   const utils = api.useUtils();
+  type FeedQuery = RouterOutputs["feed"]["get"];
+  const queryKey = getQueryKey(api.feed.get, undefined, "infinite");
+  const queryClient = useQueryClient();
   const { setDisplayLoginModal } = useGlobalContext();
   const handleSubmit = () => {
     mutate.mutate(
@@ -37,6 +42,27 @@ export default function CreateComment({
           setComment("");
           onAddComment && onAddComment();
           void utils.comments.get.invalidate({ postId });
+          queryClient.setQueriesData<InfiniteData<FeedQuery>>(
+            queryKey,
+            (prev) => {
+              const update = prev?.pages.map((page) => ({
+                ...page,
+                posts: page.posts.map((post) => {
+                  if (post.id === postId) {
+                    return {
+                      ...post,
+                      numComments: (post.numComments + 1) as number,
+                    };
+                  }
+                  return post;
+                }),
+              }));
+              if (prev && update) {
+                prev.pages = update;
+              }
+              return prev;
+            },
+          );
         },
       },
     );

--- a/src/components/Feed/Vote.tsx
+++ b/src/components/Feed/Vote.tsx
@@ -41,10 +41,8 @@ export default function Votes({
   const voteMutation = api.feed.vote.useMutation({
     // updates the post vote data on voting
     onSuccess: async (data) => {
-      console.log("QK?", queryKey);
       if (!queryKey) return;
       queryClient.setQueriesData<InfiniteData<FeedQuery>>(queryKey, (prev) => {
-        console.log("PREV?", prev);
         const update = prev?.pages.map((page) => ({
           ...page,
           posts: page.posts.map((post) => {

--- a/src/components/Feed/Vote.tsx
+++ b/src/components/Feed/Vote.tsx
@@ -1,16 +1,25 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { useGlobalContext } from "@/providers/GlobalContext";
-import { api } from "@/utils/api";
+import { api, type RouterOutputs } from "@/utils/api";
 import { cn } from "@/utils/cn";
 import { ThumbsUp, ThumbsDown } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useState } from "react";
+import {
+  useQueryClient,
+  InfiniteData,
+} from "@tanstack/react-query";
+import { getQueryKey } from "@trpc/react-query";
 
 type VotesProps = {
   upvotes: number;
   downvotes: number;
-  vote?: number | null;
   postId: number;
+  vote?: number | null;
 };
+
+type FeedQuery = RouterOutputs["feed"]["get"];
 
 export default function Votes({
   upvotes,
@@ -19,13 +28,81 @@ export default function Votes({
   postId,
 }: VotesProps) {
   const [voteDir, setVoteDir] = useState<number | undefined>(vote ?? 0);
-  const voteMutation = api.feed.vote.useMutation();
+  const [upvoteCount, setUpvoteCount] = useState(upvotes);
+  const [downvoteCount, setDownVoteCount] = useState(downvotes);
   const session = useSession();
   const { setDisplayLoginModal } = useGlobalContext();
+  const queryClient = useQueryClient();
+  const queryKey = getQueryKey(
+    api.feed.get,
+    undefined,
+    "infinite",
+  );
+  const voteMutation = api.feed.vote.useMutation({
+    // updates the post vote data on voting
+    onSuccess: async (data) => {
+      console.log("QK?", queryKey);
+      if (!queryKey) return;
+      queryClient.setQueriesData<InfiniteData<FeedQuery>>(queryKey, (prev) => {
+        console.log("PREV?", prev);
+        const update = prev?.pages.map((page) => ({
+          ...page,
+          posts: page.posts.map((post) => {
+            if (post.id === postId) {
+              return {
+                ...post,
+                upvotes: data.post.upvotes,
+                downvotes: data.post.downvotes,
+                votes: [
+                  {
+                    id: data.vote.id,
+                    postId: data.vote.postId,
+                    userId: data.vote.userId,
+                    vote: data.vote.vote,
+                  },
+                ],
+              };
+            }
+            return post;
+          }),
+        }));
+        if (prev && update) {
+          prev.pages = update;
+        }
+        return prev;
+      });
+    },
+  });
+
   const doVote = (direction: number) => {
     if (!session.data?.user.id) {
       setDisplayLoginModal(true);
     } else {
+      // already voted, don't do anything
+      if (voteDir === direction) {
+        return;
+      }
+
+      //optimistically update the vote counts
+      if (direction === 1) {
+        setUpvoteCount((c) => c + 1);
+        if (voteDir === -1) {
+          setDownVoteCount((c) => c - 1);
+        }
+      }
+      if (direction === -1) {
+        setDownVoteCount((c) => c + 1);
+        if (voteDir === 1) {
+          setUpvoteCount((c) => c - 1);
+        }
+      }
+      if (direction === 0) {
+        if (voteDir === 1) {
+          setUpvoteCount((c) => c - 1);
+        } else if (voteDir === -1) {
+          setDownVoteCount((c) => c - 1);
+        }
+      }
       setVoteDir(direction);
       voteMutation.mutate(
         { postId, vote: direction },
@@ -34,7 +111,10 @@ export default function Votes({
             if (error.message === "UNAUTHORIZED") {
               setDisplayLoginModal(true);
             }
+            // reset optimistic updates
             setVoteDir(vote ?? 0);
+            setUpvoteCount(upvotes);
+            setDownVoteCount(downvotes);
           },
         },
       );
@@ -54,7 +134,7 @@ export default function Votes({
         }}
       >
         <ThumbsUp />
-        <span>{upvotes}</span>
+        <span>{upvoteCount}</span>
       </button>
       <button
         disabled={voteMutation.isLoading}
@@ -67,7 +147,7 @@ export default function Votes({
         }}
       >
         <ThumbsDown />
-        <span>{downvotes}</span>
+        <span>{downvoteCount}</span>
       </button>
     </div>
   );

--- a/src/components/Feed/index.tsx
+++ b/src/components/Feed/index.tsx
@@ -4,7 +4,6 @@ import { cn } from "@/utils/cn";
 import useInfiniteScroll from "./useInfiniteScroll";
 import { useCallback, useRef, Fragment } from "react";
 import { Loader } from "lucide-react";
-
 type FeedProps = {
   mode: "PROFILE" | "GROUP" | "ALL";
   profileId?: string;
@@ -69,9 +68,11 @@ export default function Feed({ mode, profileId, groupId }: FeedProps) {
             "flex items-center justify-center",
         )}
       >
-        {posts.isLoading || posts.isFetching || posts.isFetchingNextPage
-          ? <Loader className="animate-spin" />
-          : ""}
+        {posts.isLoading || posts.isFetching || posts.isFetchingNextPage ? (
+          <Loader className="animate-spin" />
+        ) : (
+          ""
+        )}
       </div>
     </div>
   );

--- a/src/server/api/routers/feed.ts
+++ b/src/server/api/routers/feed.ts
@@ -96,7 +96,7 @@ export const feedRouter = createTRPCRouter({
           },
           data: {
             upvotes:
-              input.vote === 1
+              input.vote === 1 && prev?.vote !== 1
                 ? {
                     increment: 1,
                   }
@@ -106,7 +106,7 @@ export const feedRouter = createTRPCRouter({
                     }
                   : undefined,
             downvotes:
-              input.vote === -1
+              input.vote === -1 && prev?.vote !== -1
                 ? {
                     increment: 1,
                   }

--- a/src/server/api/routers/feed.ts
+++ b/src/server/api/routers/feed.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { z } from "zod";
 
 import {
@@ -57,7 +60,65 @@ export const feedRouter = createTRPCRouter({
   vote: protectedProcedure
     .input(z.object({ postId: z.number(), vote: z.number().gte(-1).lte(1) }))
     .mutation(async ({ input, ctx }) => {
-        throw new Error("missing implementation");
-        // TODO
+      const update = await ctx.db.$transaction(async (tx) => {
+        const prev = await tx.votes.findUnique({
+          where: {
+            userId_postId: {
+              userId: ctx.session.user.id,
+              postId: input.postId,
+            },
+          },
+          select: {
+            id: true,
+            postId: true,
+            vote: true,
+          },
+        });
+        const vote = await tx.votes.upsert({
+          where: {
+            userId_postId: {
+              userId: ctx.session.user.id,
+              postId: input.postId,
+            },
+          },
+          create: {
+            postId: input.postId,
+            userId: ctx.session.user.id,
+            vote: input.vote,
+          },
+          update: {
+            vote: input.vote,
+          },
+        });
+        const post = await tx.post.update({
+          where: {
+            id: input.postId,
+          },
+          data: {
+            upvotes:
+              input.vote === 1
+                ? {
+                    increment: 1,
+                  }
+                : prev?.vote === 1
+                  ? {
+                      decrement: 1,
+                    }
+                  : undefined,
+            downvotes:
+              input.vote === -1
+                ? {
+                    increment: 1,
+                  }
+                : prev?.vote === -1
+                  ? {
+                      decrement: 1,
+                    }
+                  : undefined,
+          },
+        });
+        return {vote, post};
+      });
+      return update;
     }),
 });

--- a/src/server/api/routers/feed.ts
+++ b/src/server/api/routers/feed.ts
@@ -100,7 +100,7 @@ export const feedRouter = createTRPCRouter({
                 ? {
                     increment: 1,
                   }
-                : prev?.vote === 1
+                : prev?.vote === 1 && input.vote !== 1
                   ? {
                       decrement: 1,
                     }
@@ -110,7 +110,7 @@ export const feedRouter = createTRPCRouter({
                 ? {
                     increment: 1,
                   }
-                : prev?.vote === -1
+                : prev?.vote === -1 && input.vote !== -1
                   ? {
                       decrement: 1,
                     }


### PR DESCRIPTION
Adds voting to posts.
When voting vote counts are optimistically updated. If the vote fails the update is rolled back. 
Because the post may be cached on other pages, the queryClient is accessed on successful post of the vote to update cached vote counts on other pages. 
A similar fix was applied for comment counts on successful commenting. 