### PR TITLE
Fix Feed Switch

### DIFF
--- a/src/components/Feed/Comments/CreateComment.tsx
+++ b/src/components/Feed/Comments/CreateComment.tsx
@@ -47,6 +47,7 @@ export default function CreateComment({
             (prev) => {
               const update = prev?.pages.map((page) => ({
                 ...page,
+                props: page.props,
                 posts: page.posts.map((post) => {
                   if (post.id === postId) {
                     return {

--- a/src/components/Feed/Vote.tsx
+++ b/src/components/Feed/Vote.tsx
@@ -36,6 +36,7 @@ export default function Votes({
       queryClient.setQueriesData<InfiniteData<FeedQuery>>(queryKey, (prev) => {
         const update = prev?.pages.map((page) => ({
           ...page,
+          props: page.props,
           posts: page.posts.map((post) => {
             if (post.id === postId) {
               return {

--- a/src/components/Feed/index.tsx
+++ b/src/components/Feed/index.tsx
@@ -14,6 +14,13 @@ type FeedProps = {
 
 export default function Feed({ mode, profileId, groupId }: FeedProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const enabled = !!(
+    ((mode === "ALL" || mode == "SUBS" || mode === "FRIENDS") &&
+      !profileId &&
+      !groupId) ||
+    (mode === "PROFILE" && profileId) ||
+    (mode === "GROUP" && groupId)
+  );
   const posts = api.feed.get.useInfiniteQuery(
     {
       profileId,
@@ -22,13 +29,8 @@ export default function Feed({ mode, profileId, groupId }: FeedProps) {
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
-      enabled: !!(
-        mode === "ALL" ||
-        mode == "SUBS" ||
-        mode === "FRIENDS" ||
-        (mode === "PROFILE" && profileId) ||
-        (mode === "GROUP" && groupId)
-      ),
+      // notifyOnChangeProps: (change) => {console.log("change?", change)},
+      enabled: enabled,
       keepPreviousData: true,
     },
   );
@@ -50,32 +52,43 @@ export default function Feed({ mode, profileId, groupId }: FeedProps) {
 
   useInfiniteScroll(scrollRef.current, tryLoadMore);
 
+  const page0props = posts.data?.pages?.[0]?.props;
+  const matchProps =
+    page0props?.mode === mode &&
+    (groupId
+      ? page0props.groupId === groupId
+      : profileId
+        ? page0props.profileId === profileId
+        : true);
+
   return (
     <div className="w-full">
       <CreatePost />
       <ul className="flex w-full flex-col gap-4">
-        {posts.data?.pages.map((page, i) => (
-          <Fragment key={page.nextCursor}>
-            {page.posts.map((p) => (
-              <li key={p.id}>
-                <PostCard data={p} />
-              </li>
-            ))}
-            {/* <div className="text-center text-xs opacity-50">page {i + 1}</div> */}
-          </Fragment>
-        ))}
+        {enabled &&
+          matchProps &&
+          posts.data?.pages.map((page, i) => (
+            <Fragment key={page.nextCursor}>
+              {page.posts.map((p) => (
+                <li key={p.id}>
+                  <PostCard data={p} />
+                </li>
+              ))}
+              {/* <div className="text-center text-xs opacity-50">page {i + 1}</div> */}
+            </Fragment>
+          ))}
       </ul>
       <div
         ref={scrollRef}
         className={cn(
-          "h-20 flex items-center justify-center w-full",
+          "flex h-20 w-full items-center justify-center",
           (posts.isLoading || posts.isFetching || posts.isFetchingNextPage) &&
             "flex items-center justify-center",
         )}
       >
         {posts.isLoading || posts.isFetching || posts.isFetchingNextPage ? (
           <Loader className="animate-spin" />
-        ) : (posts.data?.pages?.flatMap(p => p.posts).length ?? 0) < 1 ? (
+        ) : (posts.data?.pages?.flatMap((p) => p.posts).length ?? 0) < 1 ? (
           <div className="text-center opacity-50">nothing here</div>
         ) : (
           <></>

--- a/src/components/Feed/index.tsx
+++ b/src/components/Feed/index.tsx
@@ -29,9 +29,9 @@ export default function Feed({ mode, profileId, groupId }: FeedProps) {
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
-      // notifyOnChangeProps: (change) => {console.log("change?", change)},
       enabled: enabled,
       keepPreviousData: true,
+      refetchInterval: 20000
     },
   );
 

--- a/src/components/Nav/SideNavElements.tsx
+++ b/src/components/Nav/SideNavElements.tsx
@@ -72,7 +72,7 @@ export default function SideNavElements() {
                     <>
                       <div
                         className={cn(
-                          "relative h-10 w-10 overflow-clip rounded-full bg-base-400",
+                          "relative h-10 w-10 flex-none overflow-clip rounded-full bg-base-400",
                           profile.isLoading && "skeleton",
                         )}
                       >

--- a/src/server/api/routers/feed.ts
+++ b/src/server/api/routers/feed.ts
@@ -89,6 +89,7 @@ export const feedRouter = createTRPCRouter({
       return {
         posts: feed,
         nextCursor,
+        props: input,
       };
     }),
   vote: protectedProcedure

--- a/src/server/api/routers/feed.ts
+++ b/src/server/api/routers/feed.ts
@@ -52,6 +52,7 @@ export const feedRouter = createTRPCRouter({
                   friendsB: {
                     some: {
                       friendAId: ctx.session?.user.id,
+                      status: "ACCEPTED"
                     },
                   },
                 }


### PR DESCRIPTION
Checks that props returned in query matches input props before rendering the feed. Prevents mismatch of feed contents and current page when switching between profile or group pages. 