### PR TITLE
Remove window origin for next auth callback url

### DIFF
--- a/src/components/_container.tsx
+++ b/src/components/_container.tsx
@@ -65,9 +65,7 @@ const Container = ({ Component, pageProps }: AppProps) => {
                           <button
                             className="w-full btn btn-accent my-1 rounded-full text-base-100"
                             onClick={() =>
-                              signIn(provider.id, {
-                                callbackUrl: `${window.location.origin}`,
-                              })
+                              signIn(provider.id)
                             }
                           >
                             Sign in with {provider.name}

--- a/src/pages/auth/signin.tsx
+++ b/src/pages/auth/signin.tsx
@@ -22,9 +22,7 @@ export default function SignIn({ providers }: { providers: Provider[] }) {
                 <button
                   className="btn btn-accent"
                   onClick={() =>
-                    signIn(provider.id, {
-                      callbackUrl: `${window.location.origin}`,
-                    })
+                    signIn(provider.id)
                   }
                 >
                   Sign in with {provider.name}


### PR DESCRIPTION
Fixes issue in production environments with invalid callback url. Window object is not available when generating pages with SSR so this was producing an invalid callback URL. 